### PR TITLE
Add docker_mlx_cpp to Docker section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -35,6 +35,7 @@ Contribution guidelines forthcoming. If you have something to add before then, y
 
 ### Docker
 - A [Tech Preview](https://www.docker.com/blog/download-and-try-the-tech-preview-of-docker-desktop-for-m1/) is available. 2020-12-16
+- [docker_mlx_cpp](https://github.com/RobotFlow-Labs/docker_mlx_cpp) - Give Docker containers full Apple Silicon Metal GPU access. 107+ operations via MLX.
 
 ## Windows
 


### PR DESCRIPTION
## Summary

Adding [docker_mlx_cpp](https://github.com/RobotFlow-Labs/docker_mlx_cpp) to the **Docker** section.

**docker_mlx_cpp** gives Docker containers full Apple Silicon Metal GPU access — the NVIDIA Container Toolkit equivalent for Mac. It supports 107+ GPU operations via MLX including LLM inference, training, image generation, audio processing, and embeddings.

- Open source (MIT licensed)
- Host-side MLX daemon + Docker gateway architecture
- Works with any container on Apple Silicon